### PR TITLE
Filter out non JSON file types

### DIFF
--- a/services/messages.js
+++ b/services/messages.js
@@ -206,7 +206,10 @@ var processDirectoryItem = function(itemPath, item) {
             log.info('parsing schemas in path: ' + fullPath);
             var schemas = fs.readdirSync(fullPath);
             schemas.forEach(function(schemaFile) {
-                loadSchema(fullPath, schemaFile);
+                // We only want to load pure JSON files
+                if (/\.json$/.test(schemaFile)) {
+                    loadSchema(fullPath, schemaFile);
+                }
             });
         } else if (item === 'browser') {
             var clients = fs.readdirSync(fullPath);


### PR DESCRIPTION
This got the service up and running for me. Fixes #42 .  Like https://travis-ci.org/nitrogenjs/service, I am not able to run tests. 